### PR TITLE
fix(compile-tasks): propagate appup errors instead of crashing the build

### DIFF
--- a/lib/jellyfish/tasks/compile/copy_appup.ex
+++ b/lib/jellyfish/tasks/compile/copy_appup.ex
@@ -28,25 +28,35 @@ defmodule Mix.Tasks.Compile.CopyAppup do
     app_name = Mix.Project.config()[:app]
     release_path = Keyword.fetch!(args, :release_path)
 
-    # Trigger application copy
-    :ok = trigger_copy(release_path, app_name, version)
-
     dependencies = Helper.prod_dependencies(Mix.Project.config()[:deps])
 
-    # Trigger dependencies copy (only once per library)
-    Enum.each(dependencies, fn library ->
-      with true <- Cache.first_run_copy_appup?(library),
-           %{version: dep_version} <- Cache.get_app(library) do
-        :ok = trigger_copy(release_path, library, dep_version)
-      end
-    end)
-
-    :ok
+    with :ok <- trigger_copy(release_path, app_name, version) do
+      trigger_deps_copy(release_path, dependencies)
+    end
   end
 
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+
+  # Trigger dependencies copy (only once per library)
+  defp trigger_deps_copy(release_path, dependencies) do
+    Enum.reduce_while(dependencies, :ok, fn library, :ok ->
+      result =
+        with true <- Cache.first_run_copy_appup?(library),
+             %{version: dep_version} <- Cache.get_app(library) do
+          trigger_copy(release_path, library, dep_version)
+        else
+          _ -> :ok
+        end
+
+      case result do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
   defp trigger_copy(release_path, app_name, version) do
     appup_source = "rel/appups/#{app_name}"
 

--- a/lib/jellyfish/tasks/compile/gen_appup.ex
+++ b/lib/jellyfish/tasks/compile/gen_appup.ex
@@ -47,23 +47,33 @@ defmodule Mix.Tasks.Compile.GenAppup do
       output_dir: "#{build_path}/#{Mix.env()}/rel/#{release_name}/"
     }
 
-    :ok = trigger_gen_appup(app_name, opts)
-
     dependencies = Helper.prod_dependencies(Mix.Project.config()[:deps])
 
-    # Generate dependencies appup (only once per library)
-    Enum.each(dependencies, fn dep_app ->
-      if Cache.first_run_gen_appup?(dep_app) do
-        :ok = trigger_gen_appup(app_name, %{opts | app: dep_app, type: :dependency})
-      end
-    end)
-
-    :ok
+    with :ok <- trigger_gen_appup(app_name, opts) do
+      trigger_deps_gen_appup(app_name, opts, dependencies)
+    end
   end
 
   ### ==========================================================================
   ### Private functions
   ### ==========================================================================
+
+  # Generate dependencies appup (only once per library)
+  defp trigger_deps_gen_appup(app_name, opts, dependencies) do
+    Enum.reduce_while(dependencies, :ok, fn dep_app, :ok ->
+      result =
+        if Cache.first_run_gen_appup?(dep_app) do
+          trigger_gen_appup(app_name, %{opts | app: dep_app, type: :dependency})
+        else
+          :ok
+        end
+
+      case result do
+        :ok -> {:cont, :ok}
+        error -> {:halt, error}
+      end
+    end)
+  end
 
   defp trigger_gen_appup(root_app_name, %{app: target_app} = opts) do
     padded_name = String.pad_trailing("[#{target_app}]", @pad_app_name)
@@ -102,8 +112,19 @@ defmodule Mix.Tasks.Compile.GenAppup do
       {:error, reason} ->
         Mix.shell().info("#{padded_name} error checking appup files reason: #{inspect(reason)}")
 
-        {:error, reason}
+        {:error,
+         [diagnostic(:error, "Failed to generate appup for #{target_app}: #{inspect(reason)}")]}
     end
+  end
+
+  defp diagnostic(severity, message, file \\ Mix.Project.project_file()) do
+    %Mix.Task.Compiler.Diagnostic{
+      compiler_name: "GenAppup",
+      file: file,
+      position: nil,
+      severity: severity,
+      message: message
+    }
   end
 
   defp do_gen_appup(%__MODULE__{

--- a/test/tasks/compile/copy_appup_test.exs
+++ b/test/tasks/compile/copy_appup_test.exs
@@ -1,0 +1,50 @@
+defmodule Mix.Tasks.Compile.CopyAppupTest do
+  use ExUnit.Case, async: false
+
+  @app_name Mix.Project.config()[:app]
+  @version Mix.Project.config()[:version]
+  @appup_dir "rel/appups/#{@app_name}"
+
+  setup do
+    File.rm_rf!(@appup_dir)
+
+    on_exit(fn -> File.rm_rf!("rel") end)
+
+    :ok
+  end
+
+  test "returns :ok without touching the release when no appup file exists" do
+    release_path = Path.join(System.tmp_dir!(), "jellyfish_copy_appup_test_no_appup")
+    File.rm_rf!(release_path)
+
+    assert :ok = Mix.Tasks.Compile.CopyAppup.run(release_path: release_path)
+  end
+
+  test "returns an error diagnostic, instead of crashing, when more than one appup file matches the target version" do
+    File.mkdir_p!(@appup_dir)
+    File.write!(Path.join(@appup_dir, "0.1.0_to_#{@version}.appup"), "{}.")
+    File.write!(Path.join(@appup_dir, "0.1.1_to_#{@version}.appup"), "{}.")
+    File.write!(Path.join(@appup_dir, "jellyfish.json"), "{}")
+
+    release_path = Path.join(System.tmp_dir!(), "jellyfish_copy_appup_test_ambiguous")
+    File.rm_rf!(release_path)
+
+    assert {:error, [%Mix.Task.Compiler.Diagnostic{compiler_name: "CopyAppup"}]} =
+             Mix.Tasks.Compile.CopyAppup.run(release_path: release_path)
+  end
+
+  test "copies the appup and jellyfish files to the release when exactly one match is found" do
+    File.mkdir_p!(@appup_dir)
+    File.write!(Path.join(@appup_dir, "0.1.0_to_#{@version}.appup"), "{}.")
+    File.write!(Path.join(@appup_dir, "jellyfish.json"), "{}")
+
+    release_path = Path.join(System.tmp_dir!(), "jellyfish_copy_appup_test_single_match")
+    destination_dir = "#{release_path}/lib/#{@app_name}-#{@version}/ebin"
+    File.rm_rf!(release_path)
+    File.mkdir_p!(destination_dir)
+
+    assert :ok = Mix.Tasks.Compile.CopyAppup.run(release_path: release_path)
+    assert File.exists?("#{destination_dir}/#{@app_name}.appup")
+    assert File.exists?("#{destination_dir}/jellyfish.json")
+  end
+end

--- a/test/tasks/compile/gen_appup_test.exs
+++ b/test/tasks/compile/gen_appup_test.exs
@@ -1,0 +1,17 @@
+defmodule Mix.Tasks.Compile.GenAppupTest do
+  use ExUnit.Case, async: false
+
+  @app_name Mix.Project.config()[:app]
+
+  setup do
+    on_exit(fn -> File.rm_rf!("rel") end)
+
+    :ok
+  end
+
+  test "returns :ok and skips appup generation when no previous release version exists" do
+    # No release has been assembled under _build/test/rel/<app>, so there is
+    # nothing to diff against and generation should be a no-op, not a crash.
+    assert :ok = Mix.Tasks.Compile.GenAppup.run(release_name: @app_name)
+  end
+end


### PR DESCRIPTION
## Summary
- `CopyAppup.run/1` and `GenAppup.run/1` both hard-matched `:ok = trigger_*(...)`, but the underlying helpers can legitimately return `{:error, ...}` (a stale duplicate appup file left over from a prior build, or a failed `Appup.make`). That match raised a raw `MatchError` instead of surfacing the `Mix.Task.Compiler.Diagnostic` the code already builds for exactly this case, so a recoverable build issue crashed `mix release` with an opaque stacktrace.
- Both tasks now thread the result through `with`/`Enum.reduce_while` so an error from processing the app or any dependency actually returns as `{:error, diagnostics}`, matching each module's own `@spec`.
- `GenAppup`'s error branch now wraps its reason in a proper `Mix.Task.Compiler.Diagnostic` (previously a bare `{:error, reason}` tuple), for consistency with `CopyAppup` and with the declared return type.
- Added regression tests for both tasks - previously at 0% coverage - covering the no-appup, single-match, and ambiguous-multiple-match scenarios for `CopyAppup`, and the no-previous-version path for `GenAppup`.

## Risk assessment
- **Impact:** only the appup-generation/copy path invoked during `mix release`; no change to appup content, ordering, or the happy-path output.
- **Blast radius:** two files (`lib/jellyfish/tasks/compile/copy_appup.ex`, `lib/jellyfish/tasks/compile/gen_appup.ex`), both compile tasks. Callers who never hit an error branch see no behavior change.
- **Regression risk:** low. The change is a mechanical control-flow fix (propagate instead of force-match `:ok`); verified against the new tests plus the full existing suite (49 tests, 0 failures), `mix format --check-formatted`, and `mix compile --warnings-as-errors`.
- **Rollback plan:** revert this commit; the prior crash-on-error behavior returns but nothing else is affected.

## Test plan
- [x] `mix test --warnings-as-errors` - 49 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors` - no warnings
- [x] New tests reproduce the exact MatchError scenario (multiple appup files matching the target version) and confirm it now returns a diagnostic instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)