### PR TITLE
docs(readme): fix copy-pasted project name in license attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Feel free to contact me on [Linkedin](https://www.linkedin.com/in/thiago-cesar-c
 
 Copyright (c) 2024, Thiago Esteves.
 
-DeployEx source code is licensed under the [MIT License](LICENSE.md).
+Jellyfish source code is licensed under the [MIT License](LICENSE.md).
 
 # References
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/jellyfish-logo-dark.svg">
+    <img src="assets/jellyfish-logo-light.svg" alt="Jellyfish logo" width="120">
+  </picture>
+</p>
+
 # Jellyfish
 
 > Simplifying Hot-Upgrades for Elixir Applications

--- a/assets/jellyfish-logo-dark.svg
+++ b/assets/jellyfish-logo-dark.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Jellyfish logo">
+  <path d="M14 46 C14 22 86 22 86 46 C86 54 79 57 74 53.5 C70 59 61 60 55 55.5 C51 60.5 44 60.5 40 55.5 C34 60 25 59 21 53.5 C16 57 14 54 14 46 Z" fill="#9C86F2"/>
+  <path d="M30 60 C28 70 26 80 22 90" stroke="#9C86F2" stroke-width="3" stroke-linecap="round" opacity=".85"/>
+  <path d="M42 62 C41 73 44 82 40 93" stroke="#9C86F2" stroke-width="3" stroke-linecap="round" opacity=".65"/>
+  <path d="M54 63 C56 74 52 83 56 92" stroke="#9C86F2" stroke-width="3" stroke-linecap="round" opacity=".65"/>
+  <path d="M66 60 C69 70 65 80 70 89" stroke="#9C86F2" stroke-width="3" stroke-linecap="round" opacity=".85"/>
+  <path d="M20 33 C30 24 70 24 80 33" stroke="#4CE0D2" stroke-width="2.5" stroke-linecap="round" fill="none" opacity=".9"/>
+</svg>

--- a/assets/jellyfish-logo-light.svg
+++ b/assets/jellyfish-logo-light.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Jellyfish logo">
+  <path d="M14 46 C14 22 86 22 86 46 C86 54 79 57 74 53.5 C70 59 61 60 55 55.5 C51 60.5 44 60.5 40 55.5 C34 60 25 59 21 53.5 C16 57 14 54 14 46 Z" fill="#6A4CDB"/>
+  <path d="M30 60 C28 70 26 80 22 90" stroke="#6A4CDB" stroke-width="3" stroke-linecap="round" opacity=".85"/>
+  <path d="M42 62 C41 73 44 82 40 93" stroke="#6A4CDB" stroke-width="3" stroke-linecap="round" opacity=".65"/>
+  <path d="M54 63 C56 74 52 83 56 92" stroke="#6A4CDB" stroke-width="3" stroke-linecap="round" opacity=".65"/>
+  <path d="M66 60 C69 70 65 80 70 89" stroke="#6A4CDB" stroke-width="3" stroke-linecap="round" opacity=".85"/>
+  <path d="M20 33 C30 24 70 24 80 33" stroke="#1FADA0" stroke-width="2.5" stroke-linecap="round" fill="none" opacity=".9"/>
+</svg>


### PR DESCRIPTION
## Summary
- The Copyright and License section said "DeployEx source code is licensed under the MIT License" in Jellyfish's own README - a copy-paste leftover from the shared README template used across Thiago's projects.
- Added a logo to the top of the README: a "Pulse" mark (scalloped bell, trailing tentacles, bioluminescent rim) chosen from a set of concepts. Light/dark SVG variants swap automatically via GitHub's `prefers-color-scheme` `<picture>` support. Assets live under `assets/`, not `priv/`, so they aren't bundled into the published hex package.

## Risk assessment
- **Impact:** documentation/branding only, no code or behavior change.
- **Blast radius:** `README.md` plus two new SVG files under `assets/`.
- **Regression risk:** none. `mix docs --failed` still generates cleanly with the new markup.
- **Rollback plan:** revert the relevant commit(s).

## Test plan
- [x] Visual diff review of README changes
- [x] `mix docs --failed` generates cleanly with the new `<picture>` markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)