### PR TITLE
refactor(appup): drop the unused transforms parameter from Appup.make

### DIFF
--- a/lib/jellyfish/releases/appup.ex
+++ b/lib/jellyfish/releases/appup.ex
@@ -45,9 +45,7 @@ defmodule Jellyfish.Releases.Appup do
 
   """
   @spec make(app, version_str, version_str, path_str, path_str) :: {:ok, appup} | {:error, term}
-  @spec make(app, version_str, version_str, path_str, path_str, [module]) ::
-          {:ok, appup} | {:error, term}
-  def make(application, v1, v2, v1_path, v2_path, transforms \\ []) do
+  def make(application, v1, v2, v1_path, v2_path) do
     v1_dotapp =
       v1_path
       |> Path.join("/ebin/")
@@ -80,8 +78,7 @@ defmodule Jellyfish.Releases.Appup do
                        v1_props,
                        v2,
                        v2_path,
-                       v2_props,
-                       transforms
+                       v2_props
                      )}
 
                   false ->
@@ -106,7 +103,7 @@ defmodule Jellyfish.Releases.Appup do
     end
   end
 
-  defp make_appup(_app, v1, v1_path, _v1_props, v2, v2_path, _v2_props, _transforms) do
+  defp make_appup(_app, v1, v1_path, _v1_props, v2, v2_path, _v2_props) do
     v1 = String.to_charlist(v1)
     v2 = String.to_charlist(v2)
     v1_path = String.to_charlist(Path.join(v1_path, "ebin"))

--- a/lib/jellyfish/tasks/compile/gen_appup.ex
+++ b/lib/jellyfish/tasks/compile/gen_appup.ex
@@ -198,7 +198,7 @@ defmodule Mix.Tasks.Compile.GenAppup do
             end
         end
 
-      case Appup.make(app, v1, v2, v1_path, v2_path, _transforms = []) do
+      case Appup.make(app, v1, v2, v1_path, v2_path) do
         {:error, _} = err ->
           err
 


### PR DESCRIPTION
## Summary
- `Appup.make/6` carried a `transforms` argument and `[module]` typespec straight over from Distillery's original `appups.ex`, where it fed a `Transform.up/down` plugin behaviour letting custom modules rewrite the generated instruction list (e.g. force `:soft_purge`). Jellyfish never ported that behaviour - the parameter was bound to `_transforms` and silently discarded, so passing anything there did nothing, with no error or warning.
- Confirmed with the maintainer this is intentional scope, not a gap to fill: Jellyfish's model is deliberately simpler than Distillery's - no per-app transform plugins, generation runs automatically as a release step, and the one supported way to hand-tweak an appup is `EDIT_APPUP` for local testing (not CI).
- So this drops the dead parameter and its redundant 6-arity `@spec` rather than implementing the missing behaviour. `Appup.make` is now `make/5`. The only internal caller (`GenAppup`) already always passed `[]`, so no runtime behavior changes.

## Risk assessment
- **Impact:** `Appup.make/6` no longer exists (`make/5` only). This is a public function in a published hex package, so technically a backwards-incompatible signature change for anyone calling `make/6` directly - though since the 6th argument never did anything, no caller's behavior could have depended on its value. Worth a line in the next version's CHANGELOG when cutting a release.
- **Blast radius:** two files; the only internal caller (`GenAppup`) updated in the same commit.
- **Regression risk:** low. Full suite passes unchanged; existing `Appup` tests already called the 5-arg form.
- **Rollback plan:** revert this commit.

## Test plan
- [x] `mix test --warnings-as-errors` - 49 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors` - no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)