### PR TITLE
docs+fix: correct Cache.store_app_version/2 spec, document public API

### DIFF
--- a/lib/jellyfish/cache.ex
+++ b/lib/jellyfish/cache.ex
@@ -40,9 +40,11 @@ defmodule Jellyfish.Cache do
   Stores application version information in the process cache.
 
   The version is stored as a map with a `:version` key, allowing for future
-  extension with additional metadata if needed.
+  extension with additional metadata if needed. Returns whatever was
+  previously cached for `app` (as `Process.put/2` does), or `nil` if this is
+  the first time `app` is stored.
   """
-  @spec store_app_version(atom() | String.t(), String.t()) :: %{version: String.t()}
+  @spec store_app_version(atom() | String.t(), String.t()) :: %{version: String.t()} | nil
   def store_app_version(app, version) do
     Process.put(app, %{version: version})
   end

--- a/lib/jellyfish/jellyfish.ex
+++ b/lib/jellyfish/jellyfish.ex
@@ -3,6 +3,22 @@ defmodule Jellyfish do
   This module is responsible for generating appup/jellyfish files and moving it to the release folder.
   """
 
+  @doc """
+  Release step that generates appup files and copies them into the release.
+
+  Meant to be plugged into a release's `:steps`, after `:assemble`:
+
+      releases: [
+        my_app: [
+          steps: [:assemble, &Jellyfish.generate/1, :tar]
+        ]
+      ]
+
+  It runs the `compile.gen_appup` and `compile.copy_appup` Mix compiler tasks
+  for the release's app and its production dependencies, then copies the
+  freshly assembled `.rel` file into the release's `releases/` directory.
+  Returns the given `release` unchanged, as required by the `:steps` contract.
+  """
   @spec generate(Mix.Release.t()) :: Mix.Release.t()
   def generate(%Mix.Release{name: name, version: vsn, path: path, version_path: vp} = release) do
     Mix.shell().info([

--- a/lib/jellyfish/releases/appup.ex
+++ b/lib/jellyfish/releases/appup.ex
@@ -5,16 +5,29 @@ defmodule Jellyfish.Releases.Appup do
   Copied and/or modified from https://github.com/bitwalker/distillery/blob/master/lib/distillery/releases/appups.ex
   """
 
+  @typedoc "An OTP application name."
   @type app :: atom
+
+  @typedoc "A version string, such as `\"0.0.1\"`."
   @type version_str :: String.t()
+
+  @typedoc "A filesystem path to a release or build artifact directory."
   @type path_str :: String.t()
+
+  @typedoc "The purge mode used for a `:update` instruction."
   @type change :: :soft | {:advanced, [term]}
+
+  @typedoc "Modules that must be loaded/updated before the module being instructed."
   @type dep_mods :: [module]
 
-  # Appup versions can be a version string as a charlist,
-  # or a regular expression as a binary. The regex must match
-  # the entire version string for an application, or it is rejected.
+  @typedoc """
+  An appup version, as expected by the `.appup` format: either a version
+  string as a charlist, or a regular expression as a binary. The regex must
+  match the entire version string for an application, or it is rejected.
+  """
   @type appup_ver :: charlist | binary
+
+  @typedoc "A single upgrade/downgrade instruction, as defined by the Erlang appup format."
   @type instruction ::
           {:add_module, module}
           | {:delete_module, module}
@@ -28,8 +41,14 @@ defmodule Jellyfish.Releases.Appup do
           | {:restart_application, atom}
           | :restart_new_emulator
           | :restart_emulator
+
+  @typedoc "The instructions to run, per source version, when upgrading."
   @type upgrade_instructions :: [{appup_ver, instruction}]
+
+  @typedoc "The instructions to run, per source version, when downgrading."
   @type downgrade_instructions :: [{appup_ver, instruction}]
+
+  @typedoc "The contents of a generated `.appup` file: `{new_version, upgrades, downgrades}`."
   @type appup :: {appup_ver, upgrade_instructions, downgrade_instructions}
 
   @doc """

--- a/lib/jellyfish/tasks/compile/copy_appup.ex
+++ b/lib/jellyfish/tasks/compile/copy_appup.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Compile.CopyAppup do
   ### ==========================================================================
 
   @impl true
-  @spec run(any()) :: :ok | {:error, [Mix.Task.Compiler.Diagnostic.t(), ...]}
+  @spec run(term()) :: :ok | {:error, [Mix.Task.Compiler.Diagnostic.t(), ...]}
   def run(args) do
     # make sure loadpaths are updated
     Mix.Task.run("loadpaths", [])


### PR DESCRIPTION
## Summary
Audited every public function's `@spec` and `@doc` across `lib/`. Found one real spec bug and a few genuine documentation gaps:

- **`Jellyfish.Cache.store_app_version/2`'s `@spec` was wrong.** It claimed to always return `%{version: String.t()}`, but the implementation is just `Process.put(app, %{version: version})` - and `Process.put/2` returns the *previous* value for that key, or `nil` the first time, not the value just stored. The project's own test suite already asserted the real behavior ("first time storing information returns nil"), so the spec simply never matched reality - a Dialyzer run would have flagged this. Fixed to `%{version: String.t()} | nil` and clarified the `@doc`.
- **`Jellyfish.generate/1` had no `@doc`.** This is the library's one and only public entry point - the function every consumer plugs into their release `:steps` - and it only had a bare `@spec`, no description. Added one explaining what it does, mirroring the `mix.exs` snippet from the README.
- **Normalized `CopyAppup.run/1`'s `@spec`** to take `term()` instead of `any()`, matching `GenAppup.run/1`'s style (equivalent to Dialyzer, just inconsistent between the two sibling compiler tasks).
- **Added `@typedoc` to every type in `Jellyfish.Releases.Appup`** - they back the public `make/5` spec's arguments and `{:ok, appup}` return value, so they show up in hexdocs' "Types" section, previously with no explanation at all.

## Risk assessment
- **Impact:** documentation and one `@spec` correction; no runtime behavior changes anywhere.
- **Blast radius:** four files, all doc/spec-only edits.
- **Regression risk:** none. Full suite passes unchanged.
- **Rollback plan:** revert this commit.

## Test plan
- [x] `mix test --warnings-as-errors` - 56 tests, 0 failures
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors` - no warnings
- [x] `mix docs --failed` generates cleanly; spot-checked the generated HTML to confirm the new `@doc`/`@typedoc` content renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)